### PR TITLE
Fix for cases where checksum file already exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [Leiningen](https://leiningen.org/) plugin for resolving Clojure(Script) depen
 Add the plugin to the `:plugins` vector of your `project.clj`:
 
 ```clojure
-:plugins [[reifyhealth/lein-git-down "0.2.1"]]
+:plugins [[reifyhealth/lein-git-down "0.2.2"]]
 ```
 
 If you have dependency specific configurations (see below), add the plugin's `inject-properties` function to your `:middleware` vector:
@@ -45,7 +45,7 @@ The available properties are:
 Below is an example `project.clj` that uses the plugin:
 
 ```clojure
-(defproject test-project "0.2.1"
+(defproject test-project "0.2.2"
     :description "A test project"
     ;; Include the plugin
     :plugins [[reifyhealth/lein-git-down "0.1.0"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject reifyhealth/lein-git-down "0.2.1"
+(defproject reifyhealth/lein-git-down "0.2.2"
   :description "A Leiningen plugin for resolving Clojure(Script) dependencies from a Git repository"
   :url "http://github.com/reifyhealth/lein-git-down"
   :license {:name "MIT"}

--- a/src/lein_git_down/git_wagon.clj
+++ b/src/lein_git_down/git_wagon.clj
@@ -191,11 +191,10 @@
                     first
                     (string/split #"/")
                     last
-                    (str "\\.[^\\.]+$")
+                    (str "\\.(?!" checksum ")[^\\.]+$")
                     re-pattern)]
     (->> (.getParentFile destination)
          file-seq
-         (remove #(= % destination))
          (filter #(->> % .getName (re-find file-re)))
          first)))
 


### PR DESCRIPTION
In general, the artifacts that are produced by calls to the Maven Wagon should be idempotent. In this particular case when resolving transitive git dependencies the checksum call was made twice. The second time it failed because the checksum file already existed and the regex confused it for the file to checksum (eg: pom or jar). This fixes the regex for these cases.