### PR TITLE
ADDED - Run jar command in context of non-bare git repo [161754839]

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [Leiningen](https://leiningen.org/) plugin for resolving Clojure(Script) depen
 Add the plugin to the `:plugins` vector of your `project.clj`:
 
 ```clojure
-:plugins [[reifyhealth/lein-git-down "0.2.2"]]
+:plugins [[reifyhealth/lein-git-down "0.3.0"]]
 ```
 
 If you have dependency specific configurations (see below), add the plugin's `inject-properties` function to your `:middleware` vector:
@@ -45,7 +45,7 @@ The available properties are:
 Below is an example `project.clj` that uses the plugin:
 
 ```clojure
-(defproject test-project "0.2.2"
+(defproject test-project "0.3.0"
     :description "A test project"
     ;; Include the plugin
     :plugins [[reifyhealth/lein-git-down "0.1.0"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject reifyhealth/lein-git-down "0.2.2"
+(defproject reifyhealth/lein-git-down "0.3.0"
   :description "A Leiningen plugin for resolving Clojure(Script) dependencies from a Git repository"
   :url "http://github.com/reifyhealth/lein-git-down"
   :license {:name "MIT"}


### PR DESCRIPTION
Leiningen uses git commands for certain functionality, but gitlibs just checkouts the code into a plain directory with no git information. One of the pieces of functionality that is rather useful is that it places the git version number into the `pom.properties` meta file in the jar if it can locate it. Now, lein-git-down will run the jar command in the context of an initialized git repository so this and other git functionality will work as expected in the original repo.