### PR TITLE
FIXED - Hooke Scope Bug [163885052]

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject reifyhealth/lein-git-down "0.3.0"
+(defproject reifyhealth/lein-git-down "0.3.1"
   :description "A Leiningen plugin for resolving Clojure(Script) dependencies from a Git repository"
   :url "http://github.com/reifyhealth/lein-git-down"
   :license {:name "MIT"}

--- a/test-project/project.clj
+++ b/test-project/project.clj
@@ -6,10 +6,12 @@
   :middleware [lein-git-down.plugin/inject-properties]
   :git-down {cheshire {:coordinates dakrone/cheshire}
              demo-deps {:coordinates puredanger/demo-deps}
-             com.cemerick/pomegranate {:coordinates cemerick/pomegranate}}
+             com.cemerick/pomegranate {:coordinates cemerick/pomegranate}
+             cljfmt {:coordinates weavejester/cljfmt :manifest-root "cljfmt"}}
   :dependencies [[com.cemerick/pomegranate "a8d0ef79d6cbbd9392dbe7f824e32dc60d46e0c0"] ;; pom based
                  [cheshire "c79ebaa3f56c365a1810f80617c80a3b62999701"]                 ;; lein based
                  [demo-deps "19d387dc11d804ab955207a263dfba5dbd15bf2c"]                ;; deps based
                  [clj-time "66ea91e68583e7ee246d375859414b9a9b7aba57"]                 ;; multiple
+                 [cljfmt "806e43b7a7d4e22b831d796f107f135d8efc986a"]                   ;; contains hooks
                  [org.clojure/clojure "1.9.0"]]
   :repositories [["public-github" {:url "git://github.com" :protocol :https}]])

--- a/test/lein_git_down/plugin_test.clj
+++ b/test/lein_git_down/plugin_test.clj
@@ -30,11 +30,14 @@
 (def clj-time-path
   "clj-time/clj-time/66ea91e68583e7ee246d375859414b9a9b7aba57")
 
+(def cljfmt-path
+  "cljfmt/cljfmt/806e43b7a7d4e22b831d796f107f135d8efc986a")
+
 (defn clean-up-artifacts!
   "Deletes all gitlibs and m2 artifacts from the local filesystem to prepare
   for testing"
   []
-  (doseq [path [pomegranate-path cheshire-path demo-deps-path clj-time-path]
+  (doseq [path [pomegranate-path cheshire-path demo-deps-path clj-time-path cljfmt-path]
           root [m2-root deps-root]]
     (let [dir (io/file root path)]
       (->> (file-seq dir)

--- a/test/lein_git_down/plugin_test.clj
+++ b/test/lein_git_down/plugin_test.clj
@@ -33,11 +33,14 @@
 (def cljfmt-path
   "cljfmt/cljfmt/806e43b7a7d4e22b831d796f107f135d8efc986a")
 
+(def test-project-path
+  "test-project/target")
+
 (defn clean-up-artifacts!
   "Deletes all gitlibs and m2 artifacts from the local filesystem to prepare
   for testing"
   []
-  (doseq [path [pomegranate-path cheshire-path demo-deps-path clj-time-path cljfmt-path]
+  (doseq [path [pomegranate-path cheshire-path demo-deps-path clj-time-path cljfmt-path test-project-path]
           root [m2-root deps-root]]
     (let [dir (io/file root path)]
       (->> (file-seq dir)
@@ -82,6 +85,10 @@
            clj-time-path
            "clj-time-66ea91e68583e7ee246d375859414b9a9b7aba57.jar"))
 
+(defn get-test-project-jar
+  []
+  (io/file "test-project/target/test-project-0.1.0.jar"))
+
 (deftest resolve-git-deps
   (testing "Resolution of git dependencies"
 
@@ -105,6 +112,10 @@
 
       (testing "for multiple project"
         (let [^File jar (get-clj-time-jar)]
+          (is (.exists jar))))
+
+      (testing "for the test project jar"
+        (let [^File jar (get-test-project-jar)]
           (is (.exists jar)))))
 
     (testing "without cleaning"
@@ -125,4 +136,8 @@
 
       (testing "for multiple project"
         (let [^File jar (get-clj-time-jar)]
+          (is (.exists jar))))
+
+      (testing "for the test project jar"
+        (let [^File jar (get-test-project-jar)]
           (is (.exists jar)))))))


### PR DESCRIPTION
When resolving jars, Maven/Aether concurrently runs the "get" command across all the missing dependencies. This makes sense when the wagon is simply retrieving a jar file from a remote repository, but we are building the jar from the source and part of the current Leiningen build process is to use `alter-var-root` as part of the robert/hooke library to alter behavior with "hooks". We are now scoping these root var changes, however the scoping is *not* thread local and so not thread-safe. This means that when we build the jar we also have to synchronize the function call so that only one thread is executing it at a time. This will slow down builds linearly per the number of git repositories that need to be resolved, but the trade-off is required to ensure safely building each dependency in isolation. When hooks are removed in Leiningen 3.0 we can revert the synchronization.

Closes https://github.com/reifyhealth/lein-git-down/issues/16