### PR TITLE
UPDATED - Improve Messaging [164092619]

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [Leiningen](https://leiningen.org/) plugin for resolving Clojure(Script) depen
 Add the plugin to the `:plugins` vector of your `project.clj`:
 
 ```clojure
-:plugins [[reifyhealth/lein-git-down "0.3.1"]]
+:plugins [[reifyhealth/lein-git-down "0.3.2"]]
 ```
 
 If you have dependency specific configurations (see below), add the plugin's `inject-properties` function to your `:middleware` vector:
@@ -48,7 +48,7 @@ Below is an example `project.clj` that uses the plugin:
 (defproject test-project "0.1.0"
     :description "A test project"
     ;; Include the plugin
-    :plugins [[reifyhealth/lein-git-down "0.3.1"]]
+    :plugins [[reifyhealth/lein-git-down "0.3.2"]]
     ;; Add the middleware to parse the custom configurations
     :middleware [lein-git-down.plugin/inject-properties]
     ;; Specify your dependencies. This is the same as any other project.clj and

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject reifyhealth/lein-git-down "0.3.1"
+(defproject reifyhealth/lein-git-down "0.3.2"
   :description "A Leiningen plugin for resolving Clojure(Script) dependencies from a Git repository"
   :url "http://github.com/reifyhealth/lein-git-down"
   :license {:name "MIT"}

--- a/src/lein_git_down/impl/git.clj
+++ b/src/lein_git_down/impl/git.clj
@@ -41,7 +41,7 @@
   [^Session session k]
   (into #{}
         (filter #(nil? (JSch/getConfig %)))
-        (string/split (or (.getConfig session k) "") #",")))
+        (some-> (.getConfig session k) (string/split #","))))
 
 (defn check-algorithms
   "Jsch fails with an NPE when an unsupported algorithm is configured in the

--- a/test/lein_git_down/plugin_test.clj
+++ b/test/lein_git_down/plugin_test.clj
@@ -1,5 +1,6 @@
 (ns lein-git-down.plugin-test
   (:require [clojure.java.io :as io]
+            [clojure.string :as string]
             [clojure.test :refer [deftest testing is]]
             [clojure.tools.gitlibs :as git]
             [leiningen.core.main :as lein])
@@ -8,9 +9,8 @@
            (java.io File)))
 
 (def m2-root
-  (->> (ClassLoader/getSystemClassLoader)
-       (.getURLs)
-       (map str)
+  (->> (string/split (System/getProperty "java.class.path")
+                     (re-pattern File/pathSeparator))
        (some #(when (.contains % ".m2") %))
        (re-find #"/.*/\.m2/repository")
        io/file))


### PR DESCRIPTION
Closes #20
Closes #21

([PT Story](https://www.pivotaltracker.com/story/show/164092619))

This PR makes a couple of updates to improve messaging per the above referenced issues:
1. Silence the gitlibs output since it can be confusing in certain situations and leads to messier output
2. Add warning messages when a user has unsupported algorithms configured in their ssh config. The Jsch library will fail with an unhelpful NPE when this happens. Adding support for user defined algorithms is out of scope (even if they are valid in up to date SSH implementations), so instead we try to be helpful about what caused the problem.

Additionally, there is a small fix for a bug when running tests on Java >= 9.