### PR TITLE
PF-604 : Improvements for tools.deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A [Leiningen](https://leiningen.org/) plugin for resolving Clojure(Script) depen
 Add the plugin to the `:plugins` vector of your `project.clj`:
 
 ```clojure
-:plugins [[reifyhealth/lein-git-down "0.3.7"]]
+:plugins [[reifyhealth/lein-git-down "0.4.0"]]
 ```
 
 If you have dependency specific configurations (see below), add the plugin's `inject-properties` function to your `:middleware` vector:
@@ -48,7 +48,7 @@ Below is an example `project.clj` that uses the plugin:
 (defproject test-project "0.1.0"
     :description "A test project"
     ;; Include the plugin
-    :plugins [[reifyhealth/lein-git-down "0.3.7"]]
+    :plugins [[reifyhealth/lein-git-down "0.4.0"]]
     ;; Add the middleware to parse the custom configurations
     :middleware [lein-git-down.plugin/inject-properties]
     ;; Specify your dependencies. This is the same as any other project.clj and

--- a/project.clj
+++ b/project.clj
@@ -1,11 +1,11 @@
-(defproject reifyhealth/lein-git-down "0.3.7"
+(defproject reifyhealth/lein-git-down "0.4.0"
   :description "A Leiningen plugin for resolving Clojure(Script) dependencies from a Git repository"
   :url "http://github.com/reifyhealth/lein-git-down"
   :license {:name "MIT"}
-  :dependencies [[org.clojure/tools.gitlibs "0.2.64"
+  :dependencies [[org.clojure/tools.gitlibs "1.0.100"
                   :exclusions [org.apache.httpcomponents/httpclient
                                org.slf4j/slf4j-api]]
-                 [leiningen "2.8.1" :scope "provided"]]
+                 [leiningen "2.9.4" :scope "provided"]]
   :deploy-repositories [["clojars" {:url "https://clojars.org/repo"
                                     :username :env/clojars_username
                                     :password :env/clojars_password

--- a/src/lein_git_down/git_wagon.clj
+++ b/src/lein_git_down/git_wagon.clj
@@ -82,10 +82,19 @@
      :exclusions (map (fn [x] {:group (namespace x) :aritfact (name x)})
                       exclusions)}))
 
+(defn deps-project-name
+  [^File f]
+  (loop [^File d (.getParentFile f)
+         path    (list f)]
+    (cond
+      (nil? d) (throw (Exception. "Could not find .gitlibs directory!"))
+      (= (.getName d) ".gitlibs") (.getName ^File (nth path 2))
+      :else (recur (.getParentFile d) (conj path d)))))
+
 (defmethod resolve-pom! :tools-deps
   [[_ ^File deps-edn]]
   (let [{:keys [paths deps]} (edn/read-string (slurp deps-edn))
-        proj-name (.. deps-edn getParentFile getParentFile getName)]
+        proj-name (deps-project-name deps-edn)]
     (pom/gen-pom
       {:group        proj-name
        :artifact     proj-name

--- a/src/lein_git_down/git_wagon.clj
+++ b/src/lein_git_down/git_wagon.clj
@@ -81,6 +81,10 @@
          path    (list deps-edn)]
     (cond
       (nil? d) (throw (Exception. "Could not find .gitlibs directory!"))
+      ;; once we hit the `.gitlibs` directory, we know that the 4th item
+      ;; in our path will be the repository root directory (named for the
+      ;; version), since the file structure is always static under .gitlibs:
+      ;; `libs/{group}/{artifact}/{version}`
       (= (.getName d) ".gitlibs") (.getCanonicalFile ^File (nth path 3))
       :else (recur (.getParentFile d) (conj path d)))))
 

--- a/src/lein_git_down/git_wagon.clj
+++ b/src/lein_git_down/git_wagon.clj
@@ -101,7 +101,7 @@
              :artifact (name lib)}]
     (cond
       url
-      (let [mvn-coords (->> dep ((juxt :group :artifact)) (apply symbol))
+      (let [mvn-coords (symbol (:group dep) (:artifact dep))
             git-coords (git-url->coords url)]
         (swap! properties assoc-in [:deps mvn-coords] {:coordinates git-coords})
         (assoc dep :version sha))
@@ -114,7 +114,7 @@
       (let [{:keys [uri rev]} (-> (io/file repo-root ".lein-git-down")
                                   slurp
                                   edn/read-string)
-            mvn-coords (->> dep ((juxt :group :artifact)) (apply symbol))
+            mvn-coords (symbol (:group dep) (:artifact dep))
             git-coords (git-url->coords uri)
             manifest-root (.toString
                             (.relativize (Paths/get (.toURI repo-root))
@@ -131,7 +131,7 @@
       (assoc dep
         :version    version
         :classifier classifier
-        :exclusions (map (fn [x] {:group (namespace x) :aritfact (name x)})
+        :exclusions (map (fn [x] {:group (namespace x) :artifact (name x)})
                          exclusions)))))
 
 (defmethod resolve-pom! :tools-deps

--- a/src/lein_git_down/git_wagon.clj
+++ b/src/lein_git_down/git_wagon.clj
@@ -19,6 +19,7 @@
             ;; using Leiningen
             [robert.hooke :as hooke])
   (:import (java.io File FileInputStream)
+           (java.nio.file Paths)
            (java.security MessageDigest)
            (org.apache.commons.codec.binary Hex)
            (org.apache.maven.wagon AbstractWagon TransferFailedException ResourceDoesNotExistException)
@@ -53,6 +54,12 @@
     (sequential? x) (into [] x)
     :else           [x]))
 
+(defn git-url->coords
+  [url]
+  (let [parts (-> url (string/split #":") last (string/split #"/"))]
+    (symbol (penultimate parts)
+            (-> parts last (string/split #"\.") first))))
+
 ;;
 ;; Resolve POM
 ;;
@@ -68,39 +75,75 @@
   (hooke/with-scope
     (io/file (lein/apply-task "pom" (project/read (str project)) []))))
 
-(defn to-dep
-  [[lib {:keys [git/url sha mvn/version classifier exclusions]}]]
-  (if url
-    (let [parts (-> url (string/split #":") last (string/split #"/"))]
-      {:group    (penultimate parts)
-       :artifact (-> parts last (string/split #"\.") first)
-       :version  sha})
-    {:group      (or (namespace lib) (name lib))
-     :artifact   (name lib)
-     :version    version
-     :classifier classifier
-     :exclusions (map (fn [x] {:group (namespace x) :aritfact (name x)})
-                      exclusions)}))
-
-(defn deps-project-name
-  [^File f]
-  (loop [^File d (.getParentFile f)
-         path    (list f)]
+(defn ^File deps-repo-root
+  [^File deps-edn]
+  (loop [^File d (.getParentFile deps-edn)
+         path    (list deps-edn)]
     (cond
       (nil? d) (throw (Exception. "Could not find .gitlibs directory!"))
-      (= (.getName d) ".gitlibs") (.getName ^File (nth path 2))
+      (= (.getName d) ".gitlibs") (.getCanonicalFile ^File (nth path 3))
       :else (recur (.getParentFile d) (conj path d)))))
 
+(defn dep-in-repo?
+  [^File repo-root ^File deps-edn ^String local-root-path]
+  (let [local-file (-> (io/file (.getParentFile deps-edn) local-root-path)
+                       .getCanonicalFile)]
+    (and (.exists (io/file local-file "deps.edn"))
+         (.startsWith (Paths/get (.toURI local-file))
+                      (Paths/get (.toURI repo-root))))))
+
+(defn to-dep
+  [^File repo-root
+   ^File deps-edn
+   properties
+   [lib {:keys [git/url sha local/root mvn/version classifier exclusions]}]]
+  (let [dep {:group    (or (namespace lib) (name lib))
+             :artifact (name lib)}]
+    (cond
+      url
+      (let [git-coords (git-url->coords url)]
+        (swap! properties assoc-in [:debs lib] {:coordinates git-coords})
+        (assoc dep :version sha))
+
+      ;; If the dependency has a local/root specification then we check
+      ;; to see if it can be resolved relative to the repository root.
+      ;; If not, there is nothing we can do and so we return the default
+      ;; dependency map.
+      (and root (dep-in-repo? repo-root deps-edn root))
+      (let [{:keys [uri rev]} (-> (io/file repo-root ".lein-git-down")
+                                  slurp
+                                  edn/read-string)
+            git-coords (git-url->coords uri)
+            manifest-root (.toString
+                            (.relativize (Paths/get (.toURI repo-root))
+                                         (-> (io/file (.getParentFile deps-edn)
+                                                      root)
+                                             .getCanonicalFile
+                                             .toURI
+                                             Paths/get)))]
+        (swap! properties assoc-in [:deps lib] {:coordinates git-coords
+                                                :manifest-root manifest-root})
+        (assoc dep :version rev))
+
+      :else
+      (assoc dep
+        :version    version
+        :classifier classifier
+        :exclusions (map (fn [x] {:group (namespace x) :aritfact (name x)})
+                         exclusions)))))
+
 (defmethod resolve-pom! :tools-deps
-  [[_ ^File deps-edn]]
+  [[_ ^File deps-edn properties]]
   (let [{:keys [paths deps]} (edn/read-string (slurp deps-edn))
-        proj-name (deps-project-name deps-edn)]
+        repo-root (deps-repo-root deps-edn)
+        proj-name (.. repo-root getParentFile getName)
+        dependencies (map (partial to-dep repo-root deps-edn properties) deps)]
     (pom/gen-pom
       {:group        proj-name
        :artifact     proj-name
        :version      "0.1.0"
        :source-path  (or (first paths) "src")
-       :dependencies (map to-dep deps)}
+       :dependencies dependencies}
       (io/file (.getParentFile deps-edn) "pom.xml"))))
 
 (defn resolve-default-pom!
@@ -262,8 +305,8 @@
       (lein/warn "Could not find destination file to checksum"))))
 
 (defmethod get-resource! :pom
-  [{:keys [destination manifests] :as dep}]
-  (let [pom (condp #(find %2 %1) manifests
+  [{:keys [destination manifests properties] :as dep}]
+  (let [pom (condp #(some-> (find %2 %1) (conj properties)) manifests
               :maven      :>> resolve-pom!
               :leiningen  :>> resolve-pom!
               :tools-deps :>> resolve-pom!
@@ -371,7 +414,8 @@
                    :default-resource-root resource-root
                    :manifests             manifests
                    :destination           destination
-                   :version               version)
+                   :version               version
+                   :properties            properties)
             get-resource!))
       (catch InvalidRemoteException e
         (.fireTransferError this resource e TransferEvent/REQUEST_GET)

--- a/test-project/project.clj
+++ b/test-project/project.clj
@@ -14,7 +14,7 @@
                  [FundingCircle/fc4-framework "c0a9777d3bb908651a0fd4f3dd151277fa10ff93" ;; deps w/ transitive git deps
                   ;; excluding since the build requires `clojure` executable
                   ;; which is not on our CI container
-                  :exclusions [tatut/clj-chrome-devtools]]
+                  :exclusions [clj-chrome-devtools]]
                  [clj-time "66ea91e68583e7ee246d375859414b9a9b7aba57"]                   ;; multiple
                  [cljfmt "806e43b7a7d4e22b831d796f107f135d8efc986a"]                     ;; contains hooks
                  [org.clojure/clojure "1.9.0"]]

--- a/test/lein_git_down/plugin_test.clj
+++ b/test/lein_git_down/plugin_test.clj
@@ -16,7 +16,7 @@
        io/file))
 
 (def deps-root
-  (io/file (git/cache-dir)))
+  (io/file (git/cache-dir) "libs"))
 
 (def pomegranate-path
   "com/cemerick/pomegranate/a8d0ef79d6cbbd9392dbe7f824e32dc60d46e0c0")
@@ -29,6 +29,9 @@
 
 (def fc4-framework-path
   "FundingCircle/fc4-framework/c0a9777d3bb908651a0fd4f3dd151277fa10ff93")
+
+(def expound-path
+  "expound/expound/9b5778a1a4ed91e2090308a6648ee9072076925a")
 
 (def clj-time-path
   "clj-time/clj-time/66ea91e68583e7ee246d375859414b9a9b7aba57")
@@ -47,6 +50,7 @@
                 cheshire-path
                 demo-deps-path
                 fc4-framework-path
+                expound-path ;; to confirm transitive deps.edn
                 clj-time-path
                 cljfmt-path
                 test-project-path]


### PR DESCRIPTION
This PR makes some improvements to the tools.deps support, namely:

1. Fixes a bug that prevented the use of `manifest-root` config for deps.edn projects
2. Supports the `:local/root` deps.edn config when it is a relative reference to another project in the same repository

It also changes the way `deps.edn` git dependencies are named. Before the `group` and `artifact` would be the github coordinates. This allowed for easy tracking of the location as known by lein-git-down, but did not necessarily align with how other projects would reference these dependencies and could create classpath issues as the Maven resolver would not recognize them as the same project for version resolution.

The new version is an improvement, but does introduce a small edge case where if you have a project with a dependency on a deps.edn project and that deps.edn project has a dependency on another deps.edn project via git integration or via local integration (eg: a transitive deps.edn reference that is not maven) *and* you delete the local .m2 cache for the child but not the parent, then the transitive dep will not be resolved b/c the parent pom references its "maven" coords (the project name as both group and artifact) instead if its github coords (unless they are the same of course). Given this should be rare and could be resolved by removing the parent .m2 cache, it will be slotted for a future fix to close this edge case.