### PR TITLE
Remove outdated doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,18 +90,6 @@ One caveat to the above articles, the SSH library used by this plugin does not s
 
 Side note: by default the plugin overrides an internal implementation in tools.gitlibs to provide the above fix for skipping unsupported keys and to provide a fix for an error that occurs if your private key has a password. You can opt-out of this override by specifying `:monkeypatch-tools-gitlibs false` at the top level of your `project.clj` file.
 
-#### SSH Config
-
-The jsch library does not support all HostKeyAlgorithms, Ciphers, MACs, and KexAlgorithms and will warn you about unsupported configurations in your `~/.ssh/config` file. If you do want to configure these and not rely on the defaults, then the below is an example snippet that is fully supported:
-
-```
-Host github.com
-  HostKeyAlgorithms ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521,ssh-ed25519,rsa-sha2-512,rsa-sha2-256,ssh-rsa
-  Ciphers aes128-ctr,aes192-ctr,aes256-ctr
-  MACs hmac-sha2-256,hmac-sha1
-  KexAlgorithms ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha1
-```
-
 ## Rationale
 
 At a high level, the rationale is essentially the same as that of [`tools.deps`](https://clojure.org/reference/deps_and_cli):


### PR DESCRIPTION
This configuration step does not appear to be applicable any longer. When this `.ssh/config` is present, I see the error:
```
Session.connect: java.security.SignatureException: Signature encoding error
```

After removing my `.ssh/config` file, the library appears to be working.